### PR TITLE
Add subscribers page

### DIFF
--- a/src/com/platypub/feat/lists.clj
+++ b/src/com/platypub/feat/lists.clj
@@ -79,11 +79,11 @@
      :href href
      :referrer referrer}))
 
-(defn subscribers [{:keys [biff/db path-params session] :as req}]
+(defn subscribers [{:keys [biff/db path-params params session] :as req}]
   (let [{:user/keys [email]} (xt/entity db (:uid session))
         newsletter-id (parse-uuid (:id path-params))
         newsletter (xt/entity db newsletter-id)
-        items (->> (mailgun/get-list-members req (:list/address newsletter))
+        items (->> (mailgun/get-list-members req (:list/address newsletter) params)
                    :body
                    :items
                    (map subscriber-record)

--- a/src/com/platypub/feat/lists.clj
+++ b/src/com/platypub/feat/lists.clj
@@ -96,11 +96,11 @@
      [:.bg-gray-100.dark:bg-stone-800.dark:text-gray-50.flex-grow
       [:div [:a.link.text-lg {:href (str "/newsletters/" newsletter-id)}
              (or (not-empty (str/trim (:list/title newsletter))) "[No title]")]]
-      [:div.text-sm [:span.mr-3 "mailgun address"] (:list/address newsletter)]
+      [:div.text-sm [:span.mr-3 "Mailgun address"] (:list/address newsletter)]
       [:div.pt-4.pb-3 "Subscribers: " biff/nbsp (count items)]
       [:table
        [:thead.text-sm
-        [:tr [:th.text-left "email address"] [:th "joined"]]]
+        [:tr [:th.text-left "Email address"] [:th "Joined"]]]
        [:tbody
         (map list-subscriber-item items)]]])))
 

--- a/src/com/platypub/feat/lists.clj
+++ b/src/com/platypub/feat/lists.clj
@@ -62,6 +62,48 @@
   {:status 303
    :headers {"location" "/newsletters"}})
 
+(defn list-subscriber-item [{:keys [address joined-at]}]
+  (let [joined-at (some-> joined-at
+                          java.time.Instant/parse
+                          java.util.Date/from
+                          (util/format-date "yyyy-MM-dd"))]
+    [:tr
+     [:td.pr-3 address]
+     [:td joined-at]]))
+
+(defn subscriber-record [item]
+  (let [{:keys [address vars]} item
+        {:keys [href joinedAt referrer]} vars]
+    {:address address
+     :joined-at joinedAt
+     :href href
+     :referrer referrer}))
+
+(defn subscribers [{:keys [biff/db path-params session] :as req}]
+  (let [{:user/keys [email]} (xt/entity db (:uid session))
+        newsletter-id (parse-uuid (:id path-params))
+        newsletter (xt/entity db newsletter-id)
+        items (->> (mailgun/get-list-members req (:list/address newsletter))
+                   :body
+                   :items
+                   (map subscriber-record)
+                   set
+                   (sort #(compare (:joined-at %2) (:joined-at %1))))]
+    (ui/nav-page
+     {:base/head [[:script (biff/unsafe (slurp (io/resource "darkmode.js")))]]
+      :current :newsletters
+      :email email}
+     [:.bg-gray-100.dark:bg-stone-800.dark:text-gray-50.flex-grow
+      [:div [:a.link.text-lg {:href (str "/newsletters/" newsletter-id)}
+             (or (not-empty (str/trim (:list/title newsletter))) "[No title]")]]
+      [:div.text-sm [:span.mr-3 "mailgun address"] (:list/address newsletter)]
+      [:div.pt-4.pb-3 "Subscribers: " biff/nbsp (count items)]
+      [:table
+       [:thead.text-sm
+        [:tr [:th.text-left "email address"] [:th "joined"]]]
+       [:tbody
+        (map list-subscriber-item items)]]])))
+
 (defn edit-list-page [{:keys [path-params biff/db session] :as req}]
   (let [{:user/keys [email]} (xt/entity db (:uid session))
         list-id (parse-uuid (:id path-params))
@@ -99,8 +141,11 @@
         [:.h-6]]])))
 
 (defn list-list-item [{:keys [list/title xt/id]}]
-  [:.mb-4 [:a.link.block.text-lg {:href (str "/newsletters/" id)}
-           (or (not-empty (str/trim title)) "[No title]")]])
+  [:.mb-4
+   [:div [:a.link.block.text-lg {:href (str "/newsletters/" id)}
+          (or (not-empty (str/trim title)) "[No title]")]]
+   [:.text-sm.text-stone-600.dark:text-stone-300
+    [:a.hover:underline {:href (str "/newsletters/" id "/subscribers")} "Subscribers"]]])
 
 (defn lists-page [{:keys [session biff/db] :as req}]
   (let [{:user/keys [email]} (xt/entity db (:uid session))
@@ -127,4 +172,5 @@
             ["/newsletters/:id"
              ["" {:get edit-list-page
                   :post edit-list}]
-             ["/delete" {:post delete-list}]]]})
+             ["/delete" {:post delete-list}]
+             ["/subscribers" {:get subscribers}]]]})

--- a/src/com/platypub/mailgun.clj
+++ b/src/com/platypub/mailgun.clj
@@ -32,6 +32,7 @@
 (defn get-list-members [{:keys [mailgun/api-key]} address]
   (http/get (str base-url "/lists/" address "/members/pages")
             {:basic-auth ["api" api-key]
+             :query-params {:limit 1000}
              :as :json}))
 
 (defn add-sub! [{:keys [mailgun/api-key]} address params]

--- a/src/com/platypub/mailgun.clj
+++ b/src/com/platypub/mailgun.clj
@@ -29,10 +29,11 @@
             {:basic-auth ["api" api-key]
              :as :json}))
 
-(defn get-list-members [{:keys [mailgun/api-key]} address]
+(defn get-list-members [{:keys [mailgun/api-key]} address params]
   (http/get (str base-url "/lists/" address "/members/pages")
             {:basic-auth ["api" api-key]
-             :query-params {:limit 1000}
+             :query-params (merge {:subscribed true
+                                   :limit 1000} params)
              :as :json}))
 
 (defn add-sub! [{:keys [mailgun/api-key]} address params]

--- a/src/com/platypub/mailgun.clj
+++ b/src/com/platypub/mailgun.clj
@@ -29,6 +29,11 @@
             {:basic-auth ["api" api-key]
              :as :json}))
 
+(defn get-list-members [{:keys [mailgun/api-key]} address]
+  (http/get (str base-url "/lists/" address "/members/pages")
+            {:basic-auth ["api" api-key]
+             :as :json}))
+
 (defn add-sub! [{:keys [mailgun/api-key]} address params]
   (http/post (str base-url "/lists/" address "/members")
              {:basic-auth ["api" api-key]


### PR DESCRIPTION
I need this page so I implemented it, what do you think?

1. Subscribers seems to naturally fit under Newsletters much like Sites View, Preview etc.
2. Members list limit is hard-coded to 1000, default is 100. No pagination yet implemented.
3. Only lists Subscribed members. Unsubscribed members would be a separate request to support.
4.  2 & 3 can be overridden with query-params on GET subscribers
5. Uses and displays the joinedAt value; the href and referrer attributes are retrieved but not displayed.
6. Joined date display uses `util/format-date` which is UTC instead of local date time.

![subscribers-animation-2](https://user-images.githubusercontent.com/4767299/176779238-6a85297e-6f4f-4050-9007-c221d9df18f8.gif)