### PR TITLE
Filter reserved and unsafe chars in slug

### DIFF
--- a/src/com/platypub/feat/posts.clj
+++ b/src/com/platypub/feat/posts.clj
@@ -14,11 +14,11 @@
 
 (defn title->slug [title]
   (-> title
-    str/lower-case
-    (str/replace #"[/|]" "-")
-    ; RFC 3986 reserved or unsafe characters in url
-    (str/replace #"[:?#\[\]@!$&'()*+,;=\"<>%{}\\^`]" "")
-    (str/replace #"\s+" "-")))
+      str/lower-case
+      ; RFC 3986 reserved or unsafe characters in url
+      (str/replace #"[/|]" "-")
+      (str/replace #"[:?#\[\]@!$&'()*+,;=\"<>%{}\\^`]" "")
+      (str/replace #"\s+" "-")))
 
 (defn edit-post [{:keys [params] :as req}]
   (let [{:keys [id


### PR DESCRIPTION
Removes more characters in title->slug, per RFC 3986 url spec.

Reverts whitespace added in edit-post to match existing style via .cljfmt.edn, as discussed in issue https://github.com/jacobobryant/platypub/issues/27