### PR TITLE
Minor fixes

### DIFF
--- a/src/com/platypub/feat/items.clj
+++ b/src/com/platypub/feat/items.clj
@@ -225,10 +225,10 @@
          "Preview"]
         [:button.btn.flex-1 {:hx-confirm "Send newsletter?"
                              :hx-post (util/make-url "site"
-                                                    (:xt/id site)
-                                                    (:slug item-spec)
-                                                    (:xt/id item)
-                                                    "send")
+                                                     (:xt/id site)
+                                                     (:slug item-spec)
+                                                     (:xt/id item)
+                                                     "send")
                              :hx-target "body"}
          "Send"]])])))
 
@@ -242,8 +242,8 @@
                  (merge (render-email sys)
                         (when send-test
                           {:to test-address})))
-  {:status 303
-   :headers {"location" (str "send?sent=true&list-id=" list-id)}})
+  {:status 200
+   :headers {"hx-redirect" (str "send?sent=true&list-id=" list-id)}})
 
 (defn item-summary [{:keys [biff/db item-spec site] :as sys} item show]
   [:.mb-4

--- a/task
+++ b/task
@@ -78,7 +78,7 @@ restart () {
 
 auto-soft-deploy () {
   soft-deploy
-  fswatch -orl 0.1 --event=Updated --event=Removed . | while read changed ; do
+  fswatch -orl 0.1 --event=Updated --event=Removed --allow-overflow . | while read changed ; do
     soft-deploy
   done
 }

--- a/themes/default/render-email
+++ b/themes/default/render-email
@@ -44,7 +44,7 @@
      [:div (:author-name site)]
      [:div
       (format-date "d MMM yyyy" (:published-at post))
-      (when (:discourse-url site)
+      (when (not-empty (:discourse-url site))
         (list
          interpunct
          [:a {:href (comments-url opts)} "comments"]))]]]])
@@ -89,7 +89,7 @@
       (space 10)
       [:div.post-content (raw-string (:html post))]
       (space 15)
-      (when (:discourse-url site)
+      (when (not-empty (:discourse-url site))
         (list
           (button {:bg-color (:primary-color site)
                    :href (comments-url opts)

--- a/themes/default/render-site
+++ b/themes/default/render-site
@@ -144,7 +144,7 @@
        [:div.h-5]
        [:div.post-content (raw-string (:html post))]
        [:div.h-5]
-       (when-some [forum-url (:discourse-url site)]
+       (when-some [forum-url (not-empty (:discourse-url site))]
          (list
            [:div.text-xl.font-bold.mb-3 "Comments"]
            (embed-discourse {:forum-url forum-url


### PR DESCRIPTION
A few things I encountered setting up Develop in Prod:

1. An "hx-redirect" header, status 200, to redirect is necessary for the "Message sent." banner to show in prod.
2. Discourse forum URL needs to test for "" instead of nil to elide comments templating.
3. Add `--allow-overflow` fswatch flag to prevent "Event queue overflow." while running `prod-dev` task (possibly due to three themes in use?).